### PR TITLE
feat: update charts to use the new helmify

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -46,10 +46,6 @@ jobs:
           helm repo update
           helm install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --set installCRDs=true
 
-      - name: Install cluster-api-core chart
-        run: |
-          helm install cluster-api-core capi/cluster-api-core --namespace cluster-api-core --create-namespace
-
       - name: Run chart-testing (install)
         run: ct install --config ./.github/configs/ct-install.yaml
         if: steps.list-changed.outputs.changed == 'true'

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-CORE_VERSION=v1.5.1# renovate: datasource=github-releases depName=kubernetes-sigs/cluster-api
-CONTROL_PLANE_VERSION=v1.5.1# renovate: datasource=github-releases depName=kubernetes-sigs/cluster-api
-BOOTSTRAP_VERSION=v1.5.1# renovate: datasource=github-releases depName=kubernetes-sigs/cluster-api
-DOCKER_VERSION=v1.5.1# renovate: datasource=github-releases depName=kubernetes-sigs/cluster-api
+CORE_VERSION=v1.5.2# renovate: datasource=github-releases depName=kubernetes-sigs/cluster-api
+CONTROL_PLANE_VERSION=v1.5.2# renovate: datasource=github-releases depName=kubernetes-sigs/cluster-api
+BOOTSTRAP_VERSION=v1.5.2# renovate: datasource=github-releases depName=kubernetes-sigs/cluster-api
+DOCKER_VERSION=v1.5.2# renovate: datasource=github-releases depName=kubernetes-sigs/cluster-api
 AWS_VERSION=v2.2.2# renovate: datasource=github-releases depName=kubernetes-sigs/cluster-api-provider-aws
 AZURE_VERSION=v1.11.1# renovate: datasource=github-releases depName=kubernetes-sigs/cluster-api-provider-azure
 GCP_VERSION=v1.4.0# renovate: datasource=github-releases depName=kubernetes-sigs/cluster-api-provider-gcp
@@ -39,6 +39,7 @@ core: kustomize helmify yq
 	$(KUSTOMIZE) build "https://github.com/kubernetes-sigs/cluster-api/cmd/clusterctl/config/crd/?ref=${CORE_VERSION}" > charts/cluster-api-core/crds/provider-crd.yaml
 	cat core-components.yaml | $(HELMIFY) -generate-defaults -image-pull-secrets charts/cluster-api-core
 	rm core-components.yaml
+	$(YQ) -i ".nameOverride=\"\" | .fullnameOverride=\"\"" charts/cluster-api-core/values.yaml
 	@if [ $$($(YQ) ".appVersion" charts/cluster-api-core/Chart.yaml) != "${CORE_VERSION}" ]; then \
 		echo "Updating Core appVersion and chart version"; \
 		$(YQ) -i ".appVersion=\"${CORE_VERSION}\"" charts/cluster-api-core/Chart.yaml; \
@@ -50,6 +51,7 @@ control-plane: kustomize helmify yq
 	$(KUSTOMIZE) build "https://github.com/kubernetes-sigs/cluster-api/cmd/clusterctl/config/crd/?ref=${CORE_VERSION}" > charts/cluster-api-control-plane/crds/provider-crd.yaml
 	cat control-plane-components.yaml | $(HELMIFY) -generate-defaults -image-pull-secrets charts/cluster-api-control-plane
 	rm control-plane-components.yaml
+	$(YQ) -i ".nameOverride=\"\" | .fullnameOverride=\"\"" charts/cluster-api-control-plane/values.yaml
 	@if [ $$($(YQ) ".appVersion" charts/cluster-api-control-plane/Chart.yaml) != "${CONTROL_PLANE_VERSION}" ]; then \
 		echo "Updating Control Plane appVersion and chart version"; \
 		$(YQ) -i ".appVersion=\"${CONTROL_PLANE_VERSION}\"" charts/cluster-api-control-plane/Chart.yaml; \
@@ -61,6 +63,7 @@ bootstrap: kustomize helmify yq
 	$(KUSTOMIZE) build "https://github.com/kubernetes-sigs/cluster-api/cmd/clusterctl/config/crd/?ref=${CORE_VERSION}" > charts/cluster-api-bootstrap/crds/provider-crd.yaml
 	cat bootstrap-components.yaml | $(HELMIFY) -generate-defaults -image-pull-secrets charts/cluster-api-bootstrap
 	rm bootstrap-components.yaml
+	$(YQ) -i ".nameOverride=\"\" | .fullnameOverride=\"\"" charts/cluster-api-bootstrap/values.yaml
 	@if [ $$($(YQ) ".appVersion" charts/cluster-api-bootstrap/Chart.yaml) != "${BOOTSTRAP_VERSION}" ]; then \
 		echo "Updating Bootstrap appVersion and chart version"; \
 		$(YQ) -i ".appVersion=\"${BOOTSTRAP_VERSION}\"" charts/cluster-api-bootstrap/Chart.yaml; \
@@ -72,7 +75,7 @@ docker: kustomize helmify yq
 	$(KUSTOMIZE) build "https://github.com/kubernetes-sigs/cluster-api/cmd/clusterctl/config/crd/?ref=${CORE_VERSION}" > charts/cluster-api-provider-docker/crds/provider-crd.yaml
 	cat infrastructure-components-development.yaml | $(HELMIFY) -generate-defaults -image-pull-secrets charts/cluster-api-provider-docker
 	rm infrastructure-components-development.yaml
-	$(YQ) -i ".configVariables.capdDockerHost=\"\"" charts/cluster-api-provider-docker/values.yaml
+	$(YQ) -i ".nameOverride=\"capd\" | .fullnameOverride=\"\" | .configVariables.capdDockerHost=\"\"" charts/cluster-api-provider-docker/values.yaml
 	@if [ $$($(YQ) ".appVersion" charts/cluster-api-provider-docker/Chart.yaml) != "${DOCKER_VERSION}" ]; then \
 		echo "Updating Docker appVersion and chart version"; \
 		$(YQ) -i ".appVersion=\"${DOCKER_VERSION}\"" charts/cluster-api-provider-docker/Chart.yaml; \
@@ -101,7 +104,7 @@ aws: kustomize helmify yq
 # Delete the secret file since we are managing that ourselves
 	rm charts/cluster-api-provider-aws/templates/manager-bootstrap-credentials.yaml
 # Add proper credentials input and the bootstrapMode toogle to easily nullify the credentials. Also set `awsControllerIamRole` to proper empty string
-	$(YQ) -i ".configVariables.awsControllerIamRole=\"\" | .bootstrapMode="true" | del(.managerBootstrapCredentials.credentials) | .managerBootstrapCredentials.AWS_ACCESS_KEY_ID=\"\" | .managerBootstrapCredentials.AWS_SECRET_ACCESS_KEY=\"\" | .managerBootstrapCredentials.AWS_REGION=\"\" | .managerBootstrapCredentials.AWS_SESSION_TOKEN=\"\"" charts/cluster-api-provider-aws/values.yaml
+	$(YQ) -i ".nameOverride=\"capa\" | .fullnameOverride=\"\" | .configVariables.awsControllerIamRole=\"\" | .bootstrapMode="true" | del(.managerBootstrapCredentials.credentials) | .managerBootstrapCredentials.AWS_ACCESS_KEY_ID=\"\" | .managerBootstrapCredentials.AWS_SECRET_ACCESS_KEY=\"\" | .managerBootstrapCredentials.AWS_REGION=\"\" | .managerBootstrapCredentials.AWS_SESSION_TOKEN=\"\"" charts/cluster-api-provider-aws/values.yaml
 
 	@if [ $$($(YQ) ".appVersion" charts/cluster-api-provider-aws/Chart.yaml) != "${AWS_VERSION}" ]; then \
 		echo "Updating AWS appVersion and chart version"; \
@@ -168,7 +171,7 @@ gcp: kustomize helmify yq
 	# Delete the secret file since we are managing that ourselves
 	rm charts/cluster-api-provider-gcp/templates/manager-bootstrap-credentials.yaml
 	# Add the bootstrapMode toggle to easily nullify the credentials.
-	$(YQ) -i ".bootstrapMode=true" charts/cluster-api-provider-gcp/values.yaml
+	$(YQ) -i ".nameOverride=\"capg\" | .fullnameOverride=\"\" | .bootstrapMode=true" charts/cluster-api-provider-gcp/values.yaml
 	# Update the GOOGLE_APPLICATION_CREDENTIALS env var in the deployment to rely on bootstrapMode
 	$(SED) -i '/name: GOOGLE_APPLICATION_CREDENTIALS/!b; n; s/value:.*/value: {{ include "cluster-api-provider-gcp.gcpCredentialsEnv" . }}/g' charts/cluster-api-provider-gcp/templates/deployment.yaml
 

--- a/charts/cluster-api-bootstrap/Chart.yaml
+++ b/charts/cluster-api-bootstrap/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: cluster-api-bootstrap
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.6
-appVersion: "v1.5.1"
+version: 0.1.7
+appVersion: "v1.5.2"
 maintainers:
   - name: Plural
     url: https://www.plural.sh

--- a/charts/cluster-api-bootstrap/templates/_manager-helpers.tpl
+++ b/charts/cluster-api-bootstrap/templates/_manager-helpers.tpl
@@ -3,7 +3,7 @@ Create the name of the service account to use
 */}}
 {{- define "cluster-api-bootstrap.managerServiceAccountName" -}}
 {{- if .Values.serviceAccounts.manager.create }}
-{{- default (printf "%s-%s" (include "cluster-api-provider-azure.fullname" .) "manager" | trunc 63 | trimSuffix "-") .Values.serviceAccounts.manager.name }}
+{{- default (printf "%s-%s" (include "cluster-api-bootstrap.fullname" .) "manager" | trunc 63 | trimSuffix "-") .Values.serviceAccounts.manager.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccounts.manager.name }}
 {{- end }}

--- a/charts/cluster-api-bootstrap/templates/_manager-helpers.tpl
+++ b/charts/cluster-api-bootstrap/templates/_manager-helpers.tpl
@@ -1,0 +1,10 @@
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "cluster-api-bootstrap.managerServiceAccountName" -}}
+{{- if .Values.serviceAccounts.manager.create }}
+{{- default (printf "%s-%s" (include "cluster-api-provider-azure.fullname" .) "manager" | trunc 63 | trimSuffix "-") .Values.serviceAccounts.manager.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccounts.manager.name }}
+{{- end }}
+{{- end }}

--- a/charts/cluster-api-bootstrap/templates/deployment.yaml
+++ b/charts/cluster-api-bootstrap/templates/deployment.yaml
@@ -68,7 +68,7 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
-      serviceAccountName: {{ include "cluster-api-bootstrap.serviceAccountName" . }}
+      serviceAccountName: {{ include "cluster-api-bootstrap.managerServiceAccountName" . }}
       terminationGracePeriodSeconds: 10
       tolerations:
       - effect: NoSchedule

--- a/charts/cluster-api-bootstrap/templates/leader-election-rbac.yaml
+++ b/charts/cluster-api-bootstrap/templates/leader-election-rbac.yaml
@@ -38,5 +38,5 @@ roleRef:
   name: '{{ include "cluster-api-bootstrap.fullname" . }}-leader-election-role'
 subjects:
 - kind: ServiceAccount
-  name: '{{ include "cluster-api-bootstrap.serviceAccountName" . }}'
+  name: '{{ include "cluster-api-bootstrap.managerServiceAccountName" . }}'
   namespace: '{{ .Release.Namespace }}'

--- a/charts/cluster-api-bootstrap/templates/manager-rbac.yaml
+++ b/charts/cluster-api-bootstrap/templates/manager-rbac.yaml
@@ -62,5 +62,5 @@ roleRef:
   name: '{{ include "cluster-api-bootstrap.fullname" . }}-manager-role'
 subjects:
 - kind: ServiceAccount
-  name: '{{ include "cluster-api-bootstrap.serviceAccountName" . }}'
+  name: '{{ include "cluster-api-bootstrap.managerServiceAccountName" . }}'
   namespace: '{{ .Release.Namespace }}'

--- a/charts/cluster-api-bootstrap/templates/manager-sa.yaml
+++ b/charts/cluster-api-bootstrap/templates/manager-sa.yaml
@@ -1,16 +1,16 @@
-{{- if .Values.serviceAccount.create }}
+{{- if .Values.serviceAccounts.capiKubeadmBootstrapManager.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "cluster-api-bootstrap.serviceAccountName" . }}
+  name: {{ include "cluster-api-bootstrap.managerServiceAccountName" . }}
   labels:
     cluster.x-k8s.io/provider: bootstrap-kubeadm
   {{- include "cluster-api-bootstrap.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.labels }}
+  {{- with .Values.serviceAccounts.capiKubeadmBootstrapManager.labels }}
   {{ toYaml . | nindent 4 }}
   {{- end }}
   annotations:
-  {{- with .Values.serviceAccount.annotations }}
+  {{- with .Values.serviceAccounts.capiKubeadmBootstrapManager.annotations }}
   {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/charts/cluster-api-bootstrap/templates/manager-sa.yaml
+++ b/charts/cluster-api-bootstrap/templates/manager-sa.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccounts.capiKubeadmBootstrapManager.create }}
+{{- if .Values.serviceAccounts.manager.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -6,11 +6,11 @@ metadata:
   labels:
     cluster.x-k8s.io/provider: bootstrap-kubeadm
   {{- include "cluster-api-bootstrap.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccounts.capiKubeadmBootstrapManager.labels }}
+  {{- with .Values.serviceAccounts.manager.labels }}
   {{ toYaml . | nindent 4 }}
   {{- end }}
   annotations:
-  {{- with .Values.serviceAccounts.capiKubeadmBootstrapManager.annotations }}
+  {{- with .Values.serviceAccounts.manager.annotations }}
   {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/charts/cluster-api-bootstrap/values.yaml
+++ b/charts/cluster-api-bootstrap/values.yaml
@@ -11,13 +11,13 @@ controllerManager:
       allowPrivilegeEscalation: false
       capabilities:
         drop:
-        - ALL
+          - ALL
       privileged: false
       runAsGroup: 65532
       runAsUser: 65532
     image:
       repository: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller
-      tag: v1.5.1
+      tag: v1.5.2
     imagePullPolicy: IfNotPresent
     resources:
       limits: {}
@@ -28,13 +28,16 @@ crds:
   create: true
 imagePullSecrets: []
 kubernetesClusterDomain: cluster.local
-serviceAccount:
-  annotations: {}
-  create: true
-  labels: {}
-  name: ""
+serviceAccounts:
+  manager:
+    annotations: {}
+    create: true
+    labels: {}
+    name: ""
 webhookService:
   ports:
-  - port: 443
-    targetPort: webhook-server
+    - port: 443
+      targetPort: webhook-server
   type: ClusterIP
+nameOverride: ""
+fullnameOverride: ""

--- a/charts/cluster-api-control-plane/Chart.yaml
+++ b/charts/cluster-api-control-plane/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: cluster-api-control-plane
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.6
-appVersion: "v1.5.1"
+version: 0.1.7
+appVersion: "v1.5.2"
 maintainers:
   - name: Plural
     url: https://www.plural.sh

--- a/charts/cluster-api-control-plane/templates/_manager-helpers.tpl
+++ b/charts/cluster-api-control-plane/templates/_manager-helpers.tpl
@@ -1,0 +1,10 @@
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "cluster-api-control-plane.managerServiceAccountName" -}}
+{{- if .Values.serviceAccounts.manager.create }}
+{{- default (printf "%s-%s" (include "cluster-api-provider-azure.fullname" .) "manager" | trunc 63 | trimSuffix "-") .Values.serviceAccounts.manager.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccounts.manager.name }}
+{{- end }}
+{{- end }}

--- a/charts/cluster-api-control-plane/templates/_manager-helpers.tpl
+++ b/charts/cluster-api-control-plane/templates/_manager-helpers.tpl
@@ -3,7 +3,7 @@ Create the name of the service account to use
 */}}
 {{- define "cluster-api-control-plane.managerServiceAccountName" -}}
 {{- if .Values.serviceAccounts.manager.create }}
-{{- default (printf "%s-%s" (include "cluster-api-provider-azure.fullname" .) "manager" | trunc 63 | trimSuffix "-") .Values.serviceAccounts.manager.name }}
+{{- default (printf "%s-%s" (include "cluster-api-control-plane.fullname" .) "manager" | trunc 63 | trimSuffix "-") .Values.serviceAccounts.manager.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccounts.manager.name }}
 {{- end }}

--- a/charts/cluster-api-control-plane/templates/deployment.yaml
+++ b/charts/cluster-api-control-plane/templates/deployment.yaml
@@ -79,7 +79,7 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
-      serviceAccountName: {{ include "cluster-api-control-plane.serviceAccountName" . }}
+      serviceAccountName: {{ include "cluster-api-control-plane.managerServiceAccountName" . }}
       terminationGracePeriodSeconds: 10
       tolerations:
       - effect: NoSchedule

--- a/charts/cluster-api-control-plane/templates/leader-election-rbac.yaml
+++ b/charts/cluster-api-control-plane/templates/leader-election-rbac.yaml
@@ -38,5 +38,5 @@ roleRef:
   name: '{{ include "cluster-api-control-plane.fullname" . }}-leader-election-role'
 subjects:
 - kind: ServiceAccount
-  name: '{{ include "cluster-api-control-plane.serviceAccountName" . }}'
+  name: '{{ include "cluster-api-control-plane.managerServiceAccountName" . }}'
   namespace: '{{ .Release.Namespace }}'

--- a/charts/cluster-api-control-plane/templates/manager-rbac.yaml
+++ b/charts/cluster-api-control-plane/templates/manager-rbac.yaml
@@ -86,5 +86,5 @@ roleRef:
   name: '{{ include "cluster-api-control-plane.fullname" . }}-aggregated-manager-role'
 subjects:
 - kind: ServiceAccount
-  name: '{{ include "cluster-api-control-plane.serviceAccountName" . }}'
+  name: '{{ include "cluster-api-control-plane.managerServiceAccountName" . }}'
   namespace: '{{ .Release.Namespace }}'

--- a/charts/cluster-api-control-plane/templates/manager-sa.yaml
+++ b/charts/cluster-api-control-plane/templates/manager-sa.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccounts.capiKubeadmControlPlaneManager.create }}
+{{- if .Values.serviceAccounts.manager.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -6,11 +6,11 @@ metadata:
   labels:
     cluster.x-k8s.io/provider: control-plane-kubeadm
   {{- include "cluster-api-control-plane.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccounts.capiKubeadmControlPlaneManager.labels }}
+  {{- with .Values.serviceAccounts.manager.labels }}
   {{ toYaml . | nindent 4 }}
   {{- end }}
   annotations:
-  {{- with .Values.serviceAccounts.capiKubeadmControlPlaneManager.annotations }}
+  {{- with .Values.serviceAccounts.manager.annotations }}
   {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/charts/cluster-api-control-plane/templates/manager-sa.yaml
+++ b/charts/cluster-api-control-plane/templates/manager-sa.yaml
@@ -1,16 +1,16 @@
-{{- if .Values.serviceAccount.create }}
+{{- if .Values.serviceAccounts.capiKubeadmControlPlaneManager.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "cluster-api-control-plane.serviceAccountName" . }}
+  name: {{ include "cluster-api-control-plane.managerServiceAccountName" . }}
   labels:
     cluster.x-k8s.io/provider: control-plane-kubeadm
   {{- include "cluster-api-control-plane.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.labels }}
+  {{- with .Values.serviceAccounts.capiKubeadmControlPlaneManager.labels }}
   {{ toYaml . | nindent 4 }}
   {{- end }}
   annotations:
-  {{- with .Values.serviceAccount.annotations }}
+  {{- with .Values.serviceAccounts.capiKubeadmControlPlaneManager.annotations }}
   {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/charts/cluster-api-control-plane/values.yaml
+++ b/charts/cluster-api-control-plane/values.yaml
@@ -10,13 +10,13 @@ controllerManager:
       allowPrivilegeEscalation: false
       capabilities:
         drop:
-        - ALL
+          - ALL
       privileged: false
       runAsGroup: 65532
       runAsUser: 65532
     image:
       repository: registry.k8s.io/cluster-api/kubeadm-control-plane-controller
-      tag: v1.5.1
+      tag: v1.5.2
     imagePullPolicy: IfNotPresent
     resources:
       limits: {}
@@ -27,13 +27,16 @@ crds:
   create: true
 imagePullSecrets: []
 kubernetesClusterDomain: cluster.local
-serviceAccount:
-  annotations: {}
-  create: true
-  labels: {}
-  name: ""
+serviceAccounts:
+  manager:
+    annotations: {}
+    create: true
+    labels: {}
+    name: ""
 webhookService:
   ports:
-  - port: 443
-    targetPort: webhook-server
+    - port: 443
+      targetPort: webhook-server
   type: ClusterIP
+nameOverride: ""
+fullnameOverride: ""

--- a/charts/cluster-api-core/Chart.yaml
+++ b/charts/cluster-api-core/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: cluster-api-core
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.7
-appVersion: "v1.5.1"
+version: 0.1.8
+appVersion: "v1.5.2"
 maintainers:
   - name: Plural
     url: https://www.plural.sh

--- a/charts/cluster-api-core/templates/_manager-helpers.tpl
+++ b/charts/cluster-api-core/templates/_manager-helpers.tpl
@@ -3,7 +3,7 @@ Create the name of the service account to use
 */}}
 {{- define "cluster-api-core.managerServiceAccountName" -}}
 {{- if .Values.serviceAccounts.manager.create }}
-{{- default (printf "%s-%s" (include "cluster-api-provider-azure.fullname" .) "manager" | trunc 63 | trimSuffix "-") .Values.serviceAccounts.manager.name }}
+{{- default (printf "%s-%s" (include "cluster-api-core.fullname" .) "manager" | trunc 63 | trimSuffix "-") .Values.serviceAccounts.manager.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccounts.manager.name }}
 {{- end }}

--- a/charts/cluster-api-core/templates/_manager-helpers.tpl
+++ b/charts/cluster-api-core/templates/_manager-helpers.tpl
@@ -1,0 +1,10 @@
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "cluster-api-core.managerServiceAccountName" -}}
+{{- if .Values.serviceAccounts.manager.create }}
+{{- default (printf "%s-%s" (include "cluster-api-provider-azure.fullname" .) "manager" | trunc 63 | trimSuffix "-") .Values.serviceAccounts.manager.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccounts.manager.name }}
+{{- end }}
+{{- end }}

--- a/charts/cluster-api-core/templates/clusterclass-crd.yaml
+++ b/charts/cluster-api-core/templates/clusterclass-crd.yaml
@@ -410,7 +410,7 @@ spec:
                     description: NamingStrategy allows changing the naming pattern used when creating the control plane provider object.
                     properties:
                       template:
-                        description: 'Template defines the template to use for generating the name of the ControlPlane object. If not defined, it will fallback to `{{ .cluster.name }}-{{ .random }}`. If the templated string exceeds 63 characters, it will be trimmed to 58 characters and will get concatenated with a random suffix of length 5. The templating mechanism provides the following arguments: * `.cluster.name`: The name of the cluster object. * `.random`: A random alphanumeric string, without vowels, of length 5.'
+                        description: 'Template defines the template to use for generating the name of the ControlPlane object. If not defined, it will fallback to `{ .cluster.name }-{ .random }`. If the templated string exceeds 63 characters, it will be trimmed to 58 characters and will get concatenated with a random suffix of length 5. The templating mechanism provides the following arguments: * `.cluster.name`: The name of the cluster object. * `.random`: A random alphanumeric string, without vowels, of length 5.'
                         type: string
                     type: object
                   nodeDeletionTimeout:
@@ -777,7 +777,7 @@ spec:
                           description: NamingStrategy allows changing the naming pattern used when creating the MachineDeployment.
                           properties:
                             template:
-                              description: 'Template defines the template to use for generating the name of the MachineDeployment object. If not defined, it will fallback to `{{ .cluster.name }}-{{ .machineDeployment.topologyName }}-{{ .random }}`. If the templated string exceeds 63 characters, it will be trimmed to 58 characters and will get concatenated with a random suffix of length 5. The templating mechanism provides the following arguments: * `.cluster.name`: The name of the cluster object. * `.random`: A random alphanumeric string, without vowels, of length 5. * `.machineDeployment.topologyName`: The name of the MachineDeployment topology (Cluster.spec.topology.workers.machineDeployments[].name).'
+                              description: 'Template defines the template to use for generating the name of the MachineDeployment object. If not defined, it will fallback to `{ .cluster.name }-{ .machineDeployment.topologyName }-{ .random }`. If the templated string exceeds 63 characters, it will be trimmed to 58 characters and will get concatenated with a random suffix of length 5. The templating mechanism provides the following arguments: * `.cluster.name`: The name of the cluster object. * `.random`: A random alphanumeric string, without vowels, of length 5. * `.machineDeployment.topologyName`: The name of the MachineDeployment topology (Cluster.spec.topology.workers.machineDeployments[].name).'
                               type: string
                           type: object
                         nodeDeletionTimeout:

--- a/charts/cluster-api-core/templates/clusterclass-crd.yaml
+++ b/charts/cluster-api-core/templates/clusterclass-crd.yaml
@@ -406,6 +406,13 @@ spec:
                         description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
                         type: object
                     type: object
+                  namingStrategy:
+                    description: NamingStrategy allows changing the naming pattern used when creating the control plane provider object.
+                    properties:
+                      template:
+                        description: 'Template defines the template to use for generating the name of the ControlPlane object. If not defined, it will fallback to `{{ .cluster.name }}-{{ .random }}`. If the templated string exceeds 63 characters, it will be trimmed to 58 characters and will get concatenated with a random suffix of length 5. The templating mechanism provides the following arguments: * `.cluster.name`: The name of the cluster object. * `.random`: A random alphanumeric string, without vowels, of length 5.'
+                        type: string
+                    type: object
                   nodeDeletionTimeout:
                     description: 'NodeDeletionTimeout defines how long the controller will attempt to delete the Node that the Machine hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely. Defaults to 10 seconds. NOTE: This value can be overridden while defining a Cluster.Topology.'
                     type: string
@@ -766,6 +773,13 @@ spec:
                           description: 'Minimum number of seconds for which a newly created machine should be ready. Defaults to 0 (machine will be considered available as soon as it is ready) NOTE: This value can be overridden while defining a Cluster.Topology using this MachineDeploymentClass.'
                           format: int32
                           type: integer
+                        namingStrategy:
+                          description: NamingStrategy allows changing the naming pattern used when creating the MachineDeployment.
+                          properties:
+                            template:
+                              description: 'Template defines the template to use for generating the name of the MachineDeployment object. If not defined, it will fallback to `{{ .cluster.name }}-{{ .machineDeployment.topologyName }}-{{ .random }}`. If the templated string exceeds 63 characters, it will be trimmed to 58 characters and will get concatenated with a random suffix of length 5. The templating mechanism provides the following arguments: * `.cluster.name`: The name of the cluster object. * `.random`: A random alphanumeric string, without vowels, of length 5. * `.machineDeployment.topologyName`: The name of the MachineDeployment topology (Cluster.spec.topology.workers.machineDeployments[].name).'
+                              type: string
+                          type: object
                         nodeDeletionTimeout:
                           description: 'NodeDeletionTimeout defines how long the controller will attempt to delete the Node that the Machine hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely. Defaults to 10 seconds. NOTE: This value can be overridden while defining a Cluster.Topology using this MachineDeploymentClass.'
                           type: string

--- a/charts/cluster-api-core/templates/deployment.yaml
+++ b/charts/cluster-api-core/templates/deployment.yaml
@@ -79,7 +79,7 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
-      serviceAccountName: {{ include "cluster-api-core.serviceAccountName" . }}
+      serviceAccountName: {{ include "cluster-api-core.managerServiceAccountName" . }}
       terminationGracePeriodSeconds: 10
       tolerations:
       - effect: NoSchedule

--- a/charts/cluster-api-core/templates/leader-election-rbac.yaml
+++ b/charts/cluster-api-core/templates/leader-election-rbac.yaml
@@ -38,5 +38,5 @@ roleRef:
   name: '{{ include "cluster-api-core.fullname" . }}-leader-election-role'
 subjects:
 - kind: ServiceAccount
-  name: '{{ include "cluster-api-core.serviceAccountName" . }}'
+  name: '{{ include "cluster-api-core.managerServiceAccountName" . }}'
   namespace: '{{ .Release.Namespace }}'

--- a/charts/cluster-api-core/templates/manager-rbac.yaml
+++ b/charts/cluster-api-core/templates/manager-rbac.yaml
@@ -336,5 +336,5 @@ roleRef:
   name: '{{ include "cluster-api-core.fullname" . }}-aggregated-manager-role'
 subjects:
 - kind: ServiceAccount
-  name: '{{ include "cluster-api-core.serviceAccountName" . }}'
+  name: '{{ include "cluster-api-core.managerServiceAccountName" . }}'
   namespace: '{{ .Release.Namespace }}'

--- a/charts/cluster-api-core/templates/manager-sa.yaml
+++ b/charts/cluster-api-core/templates/manager-sa.yaml
@@ -1,16 +1,16 @@
-{{- if .Values.serviceAccount.create }}
+{{- if .Values.serviceAccounts.capiManager.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "cluster-api-core.serviceAccountName" . }}
+  name: {{ include "cluster-api-core.managerServiceAccountName" . }}
   labels:
     cluster.x-k8s.io/provider: cluster-api
   {{- include "cluster-api-core.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.labels }}
+  {{- with .Values.serviceAccounts.capiManager.labels }}
   {{ toYaml . | nindent 4 }}
   {{- end }}
   annotations:
-  {{- with .Values.serviceAccount.annotations }}
+  {{- with .Values.serviceAccounts.capiManager.annotations }}
   {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/charts/cluster-api-core/templates/manager-sa.yaml
+++ b/charts/cluster-api-core/templates/manager-sa.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccounts.capiManager.create }}
+{{- if .Values.serviceAccounts.manager.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -6,11 +6,11 @@ metadata:
   labels:
     cluster.x-k8s.io/provider: cluster-api
   {{- include "cluster-api-core.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccounts.capiManager.labels }}
+  {{- with .Values.serviceAccounts.manager.labels }}
   {{ toYaml . | nindent 4 }}
   {{- end }}
   annotations:
-  {{- with .Values.serviceAccounts.capiManager.annotations }}
+  {{- with .Values.serviceAccounts.manager.annotations }}
   {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/charts/cluster-api-core/values.yaml
+++ b/charts/cluster-api-core/values.yaml
@@ -13,13 +13,13 @@ controllerManager:
       allowPrivilegeEscalation: false
       capabilities:
         drop:
-        - ALL
+          - ALL
       privileged: false
       runAsGroup: 65532
       runAsUser: 65532
     image:
       repository: registry.k8s.io/cluster-api/cluster-api-controller
-      tag: v1.5.1
+      tag: v1.5.2
     imagePullPolicy: IfNotPresent
     resources:
       limits: {}
@@ -30,13 +30,16 @@ crds:
   create: true
 imagePullSecrets: []
 kubernetesClusterDomain: cluster.local
-serviceAccount:
-  annotations: {}
-  create: true
-  labels: {}
-  name: ""
+serviceAccounts:
+  manager:
+    annotations: {}
+    create: true
+    labels: {}
+    name: ""
 webhookService:
   ports:
-  - port: 443
-    targetPort: webhook-server
+    - port: 443
+      targetPort: webhook-server
   type: ClusterIP
+nameOverride: ""
+fullnameOverride: ""

--- a/charts/cluster-api-provider-aws/Chart.yaml
+++ b/charts/cluster-api-provider-aws/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cluster-api-provider-aws
 description: A Helm chart for deploying the Cluster API Provider AWS
 type: application
-version: 0.1.10
+version: 0.1.11
 appVersion: "v2.2.2"
 maintainers:
   - name: Plural

--- a/charts/cluster-api-provider-aws/templates/_controller-manager-helpers.tpl
+++ b/charts/cluster-api-provider-aws/templates/_controller-manager-helpers.tpl
@@ -1,0 +1,10 @@
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "cluster-api-provider-aws.controllerManagerServiceAccountName" -}}
+{{- if .Values.serviceAccounts.controllerManager.create }}
+{{- default (printf "%s-%s" (include "cluster-api-provider-azure.fullname" .) "controller-manager" | trunc 63 | trimSuffix "-") .Values.serviceAccounts.controllerManager.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccounts.controllerManager.name }}
+{{- end }}
+{{- end }}

--- a/charts/cluster-api-provider-aws/templates/_controller-manager-helpers.tpl
+++ b/charts/cluster-api-provider-aws/templates/_controller-manager-helpers.tpl
@@ -3,7 +3,7 @@ Create the name of the service account to use
 */}}
 {{- define "cluster-api-provider-aws.controllerManagerServiceAccountName" -}}
 {{- if .Values.serviceAccounts.controllerManager.create }}
-{{- default (printf "%s-%s" (include "cluster-api-provider-azure.fullname" .) "controller-manager" | trunc 63 | trimSuffix "-") .Values.serviceAccounts.controllerManager.name }}
+{{- default (printf "%s-%s" (include "cluster-api-provider-aws.fullname" .) "controller-manager" | trunc 63 | trimSuffix "-") .Values.serviceAccounts.controllerManager.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccounts.controllerManager.name }}
 {{- end }}

--- a/charts/cluster-api-provider-aws/templates/_helpers.tpl
+++ b/charts/cluster-api-provider-aws/templates/_helpers.tpl
@@ -15,10 +15,11 @@ If release name contains chart name it will be used as a full name.
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
 {{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
-{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- $releaseName := replace .Chart.Name "capa" .Release.Name }}
+{{- if contains $name $releaseName }}
+{{- $releaseName | trunc 63 | trimSuffix "-" }}
 {{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- printf "%s-%s" $releaseName $name | trunc 63 | trimSuffix "-" }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/cluster-api-provider-aws/templates/controller-manager-sa.yaml
+++ b/charts/cluster-api-provider-aws/templates/controller-manager-sa.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccounts.capaControllerManager.create }}
+{{- if .Values.serviceAccounts.controllerManager.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -7,12 +7,12 @@ metadata:
     cluster.x-k8s.io/provider: infrastructure-aws
     control-plane: controller-manager
   {{- include "cluster-api-provider-aws.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccounts.capaControllerManager.labels }}
+  {{- with .Values.serviceAccounts.controllerManager.labels }}
   {{ toYaml . | nindent 4 }}
   {{- end }}
   annotations:
     eks.amazonaws.com/role-arn: {{ .Values.configVariables.awsControllerIamRole }}
-  {{- with .Values.serviceAccounts.capaControllerManager.annotations }}
+  {{- with .Values.serviceAccounts.controllerManager.annotations }}
   {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/charts/cluster-api-provider-aws/templates/controller-manager-sa.yaml
+++ b/charts/cluster-api-provider-aws/templates/controller-manager-sa.yaml
@@ -1,18 +1,18 @@
-{{- if .Values.serviceAccount.create }}
+{{- if .Values.serviceAccounts.capaControllerManager.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "cluster-api-provider-aws.serviceAccountName" . }}
+  name: {{ include "cluster-api-provider-aws.controllerManagerServiceAccountName" . }}
   labels:
     cluster.x-k8s.io/provider: infrastructure-aws
     control-plane: controller-manager
   {{- include "cluster-api-provider-aws.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.labels }}
+  {{- with .Values.serviceAccounts.capaControllerManager.labels }}
   {{ toYaml . | nindent 4 }}
   {{- end }}
   annotations:
     eks.amazonaws.com/role-arn: {{ .Values.configVariables.awsControllerIamRole }}
-  {{- with .Values.serviceAccount.annotations }}
+  {{- with .Values.serviceAccounts.capaControllerManager.annotations }}
   {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/charts/cluster-api-provider-aws/templates/deployment.yaml
+++ b/charts/cluster-api-provider-aws/templates/deployment.yaml
@@ -88,7 +88,7 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
-      serviceAccountName: {{ include "cluster-api-provider-aws.serviceAccountName" . }}
+      serviceAccountName: {{ include "cluster-api-provider-aws.controllerManagerServiceAccountName" . }}
       terminationGracePeriodSeconds: 10
       tolerations:
       - effect: NoSchedule

--- a/charts/cluster-api-provider-aws/templates/leader-elect-rbac.yaml
+++ b/charts/cluster-api-provider-aws/templates/leader-elect-rbac.yaml
@@ -58,5 +58,5 @@ roleRef:
   name: '{{ include "cluster-api-provider-aws.fullname" . }}-leader-elect-role'
 subjects:
 - kind: ServiceAccount
-  name: '{{ include "cluster-api-provider-aws.serviceAccountName" . }}'
+  name: '{{ include "cluster-api-provider-aws.controllerManagerServiceAccountName" . }}'
   namespace: '{{ .Release.Namespace }}'

--- a/charts/cluster-api-provider-aws/templates/manager-rbac.yaml
+++ b/charts/cluster-api-provider-aws/templates/manager-rbac.yaml
@@ -347,5 +347,5 @@ roleRef:
   name: '{{ include "cluster-api-provider-aws.fullname" . }}-manager-role'
 subjects:
 - kind: ServiceAccount
-  name: '{{ include "cluster-api-provider-aws.serviceAccountName" . }}'
+  name: '{{ include "cluster-api-provider-aws.controllerManagerServiceAccountName" . }}'
   namespace: '{{ .Release.Namespace }}'

--- a/charts/cluster-api-provider-aws/values.yaml
+++ b/charts/cluster-api-provider-aws/values.yaml
@@ -51,14 +51,17 @@ metricsService:
       protocol: TCP
       targetPort: metrics
   type: ClusterIP
-serviceAccount:
-  annotations: {}
-  create: true
-  labels: {}
-  name: ""
+serviceAccounts:
+  controllerManager:
+    annotations: {}
+    create: true
+    labels: {}
+    name: ""
 webhookService:
   ports:
     - port: 443
       targetPort: webhook-server
   type: ClusterIP
+nameOverride: capa
+fullnameOverride: ""
 bootstrapMode: true

--- a/charts/cluster-api-provider-azure/Chart.yaml
+++ b/charts/cluster-api-provider-azure/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cluster-api-provider-azure
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.12
+version: 0.1.13
 appVersion: "v1.11.1"
 maintainers:
   - name: Plural

--- a/charts/cluster-api-provider-azure/templates/provider.yaml
+++ b/charts/cluster-api-provider-azure/templates/provider.yaml
@@ -8,4 +8,4 @@ metadata:
   name: infrastructure-azure
 providerName: azure
 type: InfrastructureProvider
-version: {{ .Values.controllerManager.manager.image.tag | default .Chart.AppVersion }}
+version: {{ .Values.capzControllerManager.manager.image.tag | default .Chart.AppVersion }}

--- a/charts/cluster-api-provider-azure/templates/provider.yaml
+++ b/charts/cluster-api-provider-azure/templates/provider.yaml
@@ -1,0 +1,11 @@
+apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
+kind: Provider
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-azure
+    clusterctl.cluster.x-k8s.io: ''
+    clusterctl.cluster.x-k8s.io/core: inventory
+  name: infrastructure-azure
+providerName: azure
+type: InfrastructureProvider
+version: {{ .Values.controllerManager.manager.image.tag | default .Chart.AppVersion }}

--- a/charts/cluster-api-provider-docker/Chart.yaml
+++ b/charts/cluster-api-provider-docker/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: cluster-api-provider-docker
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.4
-appVersion: "v1.5.1"
+version: 0.1.5
+appVersion: "v1.5.2"
 maintainers:
   - name: Plural
     url: https://www.plural.sh

--- a/charts/cluster-api-provider-docker/templates/_helpers.tpl
+++ b/charts/cluster-api-provider-docker/templates/_helpers.tpl
@@ -15,10 +15,11 @@ If release name contains chart name it will be used as a full name.
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
 {{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
-{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- $releaseName := replace .Chart.Name "capd" .Release.Name }}
+{{- if contains $name $releaseName }}
+{{- $releaseName | trunc 63 | trimSuffix "-" }}
 {{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- printf "%s-%s" $releaseName $name | trunc 63 | trimSuffix "-" }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/cluster-api-provider-docker/templates/_manager-helpers.tpl
+++ b/charts/cluster-api-provider-docker/templates/_manager-helpers.tpl
@@ -3,7 +3,7 @@ Create the name of the service account to use
 */}}
 {{- define "cluster-api-provider-docker.managerServiceAccountName" -}}
 {{- if .Values.serviceAccounts.manager.create }}
-{{- default (printf "%s-%s" (include "cluster-api-provider-azure.fullname" .) "manager" | trunc 63 | trimSuffix "-") .Values.serviceAccounts.manager.name }}
+{{- default (printf "%s-%s" (include "cluster-api-provider-docker.fullname" .) "manager" | trunc 63 | trimSuffix "-") .Values.serviceAccounts.manager.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccounts.manager.name }}
 {{- end }}

--- a/charts/cluster-api-provider-docker/templates/_manager-helpers.tpl
+++ b/charts/cluster-api-provider-docker/templates/_manager-helpers.tpl
@@ -1,0 +1,10 @@
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "cluster-api-provider-docker.managerServiceAccountName" -}}
+{{- if .Values.serviceAccounts.manager.create }}
+{{- default (printf "%s-%s" (include "cluster-api-provider-azure.fullname" .) "manager" | trunc 63 | trimSuffix "-") .Values.serviceAccounts.manager.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccounts.manager.name }}
+{{- end }}
+{{- end }}

--- a/charts/cluster-api-provider-docker/templates/deployment.yaml
+++ b/charts/cluster-api-provider-docker/templates/deployment.yaml
@@ -77,7 +77,7 @@ spec:
           name: dockersock
       imagePullSecrets: {{ .Values.imagePullSecrets | default list | toJson }}
       nodeSelector: {{- toYaml .Values.controllerManager.nodeSelector | nindent 8 }}
-      serviceAccountName: {{ include "cluster-api-provider-docker.serviceAccountName" . }}
+      serviceAccountName: {{ include "cluster-api-provider-docker.managerServiceAccountName" . }}
       terminationGracePeriodSeconds: 10
       tolerations:
       - effect: NoSchedule

--- a/charts/cluster-api-provider-docker/templates/leader-election-rbac.yaml
+++ b/charts/cluster-api-provider-docker/templates/leader-election-rbac.yaml
@@ -38,5 +38,5 @@ roleRef:
   name: '{{ include "cluster-api-provider-docker.fullname" . }}-leader-election-role'
 subjects:
 - kind: ServiceAccount
-  name: '{{ include "cluster-api-provider-docker.serviceAccountName" . }}'
+  name: '{{ include "cluster-api-provider-docker.managerServiceAccountName" . }}'
   namespace: '{{ .Release.Namespace }}'

--- a/charts/cluster-api-provider-docker/templates/manager-rbac.yaml
+++ b/charts/cluster-api-provider-docker/templates/manager-rbac.yaml
@@ -110,5 +110,5 @@ roleRef:
   name: '{{ include "cluster-api-provider-docker.fullname" . }}-manager-role'
 subjects:
 - kind: ServiceAccount
-  name: '{{ include "cluster-api-provider-docker.serviceAccountName" . }}'
+  name: '{{ include "cluster-api-provider-docker.managerServiceAccountName" . }}'
   namespace: '{{ .Release.Namespace }}'

--- a/charts/cluster-api-provider-docker/templates/manager-sa.yaml
+++ b/charts/cluster-api-provider-docker/templates/manager-sa.yaml
@@ -1,16 +1,16 @@
-{{- if .Values.serviceAccount.create }}
+{{- if .Values.serviceAccounts.capdManager.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "cluster-api-provider-docker.serviceAccountName" . }}
+  name: {{ include "cluster-api-provider-docker.managerServiceAccountName" . }}
   labels:
     cluster.x-k8s.io/provider: infrastructure-docker
   {{- include "cluster-api-provider-docker.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.labels }}
+  {{- with .Values.serviceAccounts.capdManager.labels }}
   {{ toYaml . | nindent 4 }}
   {{- end }}
   annotations:
-  {{- with .Values.serviceAccount.annotations }}
+  {{- with .Values.serviceAccounts.capdManager.annotations }}
   {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/charts/cluster-api-provider-docker/templates/manager-sa.yaml
+++ b/charts/cluster-api-provider-docker/templates/manager-sa.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccounts.capdManager.create }}
+{{- if .Values.serviceAccounts.manager.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -6,11 +6,11 @@ metadata:
   labels:
     cluster.x-k8s.io/provider: infrastructure-docker
   {{- include "cluster-api-provider-docker.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccounts.capdManager.labels }}
+  {{- with .Values.serviceAccounts.manager.labels }}
   {{ toYaml . | nindent 4 }}
   {{- end }}
   annotations:
-  {{- with .Values.serviceAccounts.capdManager.annotations }}
+  {{- with .Values.serviceAccounts.manager.annotations }}
   {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/charts/cluster-api-provider-docker/templates/provider.yaml
+++ b/charts/cluster-api-provider-docker/templates/provider.yaml
@@ -1,0 +1,11 @@
+apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
+kind: Provider
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-docker
+    clusterctl.cluster.x-k8s.io: ''
+    clusterctl.cluster.x-k8s.io/core: inventory
+  name: infrastructure-docker
+providerName: docker
+type: InfrastructureProvider
+version: {{ .Values.controllerManager.manager.image.tag | default .Chart.AppVersion }}

--- a/charts/cluster-api-provider-docker/values.yaml
+++ b/charts/cluster-api-provider-docker/values.yaml
@@ -11,7 +11,7 @@ controllerManager:
       privileged: true
     image:
       repository: gcr.io/k8s-staging-cluster-api/capd-manager
-      tag: v1.5.1
+      tag: v1.5.2
     imagePullPolicy: IfNotPresent
     resources:
       limits: {}
@@ -22,13 +22,16 @@ crds:
   create: true
 imagePullSecrets: []
 kubernetesClusterDomain: cluster.local
-serviceAccount:
-  annotations: {}
-  create: true
-  labels: {}
-  name: ""
+serviceAccounts:
+  manager:
+    annotations: {}
+    create: true
+    labels: {}
+    name: ""
 webhookService:
   ports:
     - port: 443
       targetPort: webhook-server
   type: ClusterIP
+nameOverride: capd
+fullnameOverride: ""

--- a/charts/cluster-api-provider-gcp/Chart.yaml
+++ b/charts/cluster-api-provider-gcp/Chart.yaml
@@ -2,5 +2,8 @@ apiVersion: v2
 name: cluster-api-provider-gcp
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.4
+version: 0.1.5
 appVersion: "v1.4.0"
+maintainers:
+  - name: Plural
+    url: https://www.plural.sh

--- a/charts/cluster-api-provider-gcp/templates/_helpers.tpl
+++ b/charts/cluster-api-provider-gcp/templates/_helpers.tpl
@@ -15,10 +15,11 @@ If release name contains chart name it will be used as a full name.
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
 {{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
-{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- $releaseName := replace .Chart.Name "capg" .Release.Name }}
+{{- if contains $name $releaseName }}
+{{- $releaseName | trunc 63 | trimSuffix "-" }}
 {{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- printf "%s-%s" $releaseName $name | trunc 63 | trimSuffix "-" }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/cluster-api-provider-gcp/templates/_manager-helpers.tpl
+++ b/charts/cluster-api-provider-gcp/templates/_manager-helpers.tpl
@@ -3,7 +3,7 @@ Create the name of the service account to use
 */}}
 {{- define "cluster-api-provider-gcp.managerServiceAccountName" -}}
 {{- if .Values.serviceAccounts.manager.create }}
-{{- default (printf "%s-%s" (include "cluster-api-provider-azure.fullname" .) "manager" | trunc 63 | trimSuffix "-") .Values.serviceAccounts.manager.name }}
+{{- default (printf "%s-%s" (include "cluster-api-provider-gcp.fullname" .) "manager" | trunc 63 | trimSuffix "-") .Values.serviceAccounts.manager.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccounts.manager.name }}
 {{- end }}

--- a/charts/cluster-api-provider-gcp/templates/_manager-helpers.tpl
+++ b/charts/cluster-api-provider-gcp/templates/_manager-helpers.tpl
@@ -1,0 +1,10 @@
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "cluster-api-provider-gcp.managerServiceAccountName" -}}
+{{- if .Values.serviceAccounts.manager.create }}
+{{- default (printf "%s-%s" (include "cluster-api-provider-azure.fullname" .) "manager" | trunc 63 | trimSuffix "-") .Values.serviceAccounts.manager.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccounts.manager.name }}
+{{- end }}
+{{- end }}

--- a/charts/cluster-api-provider-gcp/templates/deployment.yaml
+++ b/charts/cluster-api-provider-gcp/templates/deployment.yaml
@@ -84,7 +84,7 @@ spec:
           name: credentials
       imagePullSecrets: {{ .Values.imagePullSecrets | default list | toJson }}
       nodeSelector: {{- toYaml .Values.controllerManager.nodeSelector | nindent 8 }}
-      serviceAccountName: {{ include "cluster-api-provider-gcp.serviceAccountName" . }}
+      serviceAccountName: {{ include "cluster-api-provider-gcp.managerServiceAccountName" . }}
       terminationGracePeriodSeconds: 10
       tolerations:
       - effect: NoSchedule

--- a/charts/cluster-api-provider-gcp/templates/leader-election-rbac.yaml
+++ b/charts/cluster-api-provider-gcp/templates/leader-election-rbac.yaml
@@ -58,5 +58,5 @@ roleRef:
   name: '{{ include "cluster-api-provider-gcp.fullname" . }}-leader-election-role'
 subjects:
 - kind: ServiceAccount
-  name: '{{ include "cluster-api-provider-gcp.serviceAccountName" . }}'
+  name: '{{ include "cluster-api-provider-gcp.managerServiceAccountName" . }}'
   namespace: '{{ .Release.Namespace }}'

--- a/charts/cluster-api-provider-gcp/templates/manager-rbac.yaml
+++ b/charts/cluster-api-provider-gcp/templates/manager-rbac.yaml
@@ -188,5 +188,5 @@ roleRef:
   name: '{{ include "cluster-api-provider-gcp.fullname" . }}-manager-role'
 subjects:
 - kind: ServiceAccount
-  name: '{{ include "cluster-api-provider-gcp.serviceAccountName" . }}'
+  name: '{{ include "cluster-api-provider-gcp.managerServiceAccountName" . }}'
   namespace: '{{ .Release.Namespace }}'

--- a/charts/cluster-api-provider-gcp/templates/manager-sa.yaml
+++ b/charts/cluster-api-provider-gcp/templates/manager-sa.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccounts.capgManager.create }}
+{{- if .Values.serviceAccounts.manager.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -6,11 +6,11 @@ metadata:
   labels:
     cluster.x-k8s.io/provider: infrastructure-gcp
   {{- include "cluster-api-provider-gcp.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccounts.capgManager.labels }}
+  {{- with .Values.serviceAccounts.manager.labels }}
   {{ toYaml . | nindent 4 }}
   {{- end }}
   annotations:
-  {{- with .Values.serviceAccounts.capgManager.annotations }}
+  {{- with .Values.serviceAccounts.manager.annotations }}
   {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/charts/cluster-api-provider-gcp/templates/manager-sa.yaml
+++ b/charts/cluster-api-provider-gcp/templates/manager-sa.yaml
@@ -1,16 +1,16 @@
-{{- if .Values.serviceAccount.create }}
+{{- if .Values.serviceAccounts.capgManager.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "cluster-api-provider-gcp.serviceAccountName" . }}
+  name: {{ include "cluster-api-provider-gcp.managerServiceAccountName" . }}
   labels:
     cluster.x-k8s.io/provider: infrastructure-gcp
   {{- include "cluster-api-provider-gcp.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.labels }}
+  {{- with .Values.serviceAccounts.capgManager.labels }}
   {{ toYaml . | nindent 4 }}
   {{- end }}
   annotations:
-  {{- with .Values.serviceAccount.annotations }}
+  {{- with .Values.serviceAccounts.capgManager.annotations }}
   {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/charts/cluster-api-provider-gcp/templates/provider.yaml
+++ b/charts/cluster-api-provider-gcp/templates/provider.yaml
@@ -1,0 +1,11 @@
+apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
+kind: Provider
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-gcp
+    clusterctl.cluster.x-k8s.io: ''
+    clusterctl.cluster.x-k8s.io/core: inventory
+  name: infrastructure-gcp
+providerName: gcp
+type: InfrastructureProvider
+version: {{ .Values.controllerManager.manager.image.tag | default .Chart.AppVersion }}

--- a/charts/cluster-api-provider-gcp/values.yaml
+++ b/charts/cluster-api-provider-gcp/values.yaml
@@ -31,14 +31,17 @@ imagePullSecrets: []
 kubernetesClusterDomain: cluster.local
 managerBootstrapCredentials:
   credentialsJson: ""
-serviceAccount:
-  annotations: {}
-  create: true
-  labels: {}
-  name: ""
+serviceAccounts:
+  manager:
+    annotations: {}
+    create: true
+    labels: {}
+    name: ""
 webhookService:
   ports:
     - port: 443
       targetPort: webhook-server
   type: ClusterIP
+nameOverride: capg
+fullnameOverride: ""
 bootstrapMode: true


### PR DESCRIPTION
This PR updates the core CAPI providers and also has them use the new version of Helmify. It also sets a default name override for the provider charts and modifies how the full name is generated to try and ensure the 63 character limit isn't hit for names. The helmify change also allows for multiple service accounts, which has caused the configuration to have moved in the values. The change of location to set the service account annotations, along with the change in how the chart name is generated, means our artifact repo will need to be updated so IAM roles are bound to the new service account name and the annotations are set correctly.